### PR TITLE
docs(hiring): adding link to our careers page

### DIFF
--- a/hiring/README.md
+++ b/hiring/README.md
@@ -8,5 +8,7 @@ Outline of each step of our hiring process
 |--|--|
 | [Interviewing at Loadsmart](/hiring/interviewing.md#readme) | Our process to hire engineers |
 | [Referring a candidate](/hiring/referrals.md#readme) | The process of referring someone to our Engineering team |
+| [Careers](https://jobs.lever.co/loadsmart/) | Our careers page has all of our open positions |
+
 <!-- end_toc -->
 <!-- prettier-ignore-end -->

--- a/hiring/README.md
+++ b/hiring/README.md
@@ -6,9 +6,8 @@ Outline of each step of our hiring process
 <!-- start_toc -->
 | Doc | Overview |
 |--|--|
+| [Carrers](/hiring/careers.md#readme) | Our careers page has all of our [open positions](https://jobs.lever.co/loadsmart/?department=Engineering) |
 | [Interviewing at Loadsmart](/hiring/interviewing.md#readme) | Our process to hire engineers |
 | [Referring a candidate](/hiring/referrals.md#readme) | The process of referring someone to our Engineering team |
-| [Careers](https://jobs.lever.co/loadsmart/) | Our careers page has all of our open positions |
-
 <!-- end_toc -->
 <!-- prettier-ignore-end -->

--- a/hiring/README.md
+++ b/hiring/README.md
@@ -6,7 +6,7 @@ Outline of each step of our hiring process
 <!-- start_toc -->
 | Doc | Overview |
 |--|--|
-| [Carrers](/hiring/careers.md#readme) | Our careers page has all of our [open positions](https://jobs.lever.co/loadsmart/?department=Engineering) |
+| [Careers](/hiring/careers.md#readme) | Our careers page has all of our [open positions](https://jobs.lever.co/loadsmart/?department=Engineering) |
 | [Interviewing at Loadsmart](/hiring/interviewing.md#readme) | Our process to hire engineers |
 | [Referring a candidate](/hiring/referrals.md#readme) | The process of referring someone to our Engineering team |
 <!-- end_toc -->

--- a/hiring/careers.md
+++ b/hiring/careers.md
@@ -1,0 +1,8 @@
+---
+title: Carrers
+description: Our careers page has all of our [open positions](https://jobs.lever.co/loadsmart/?department=Engineering)
+---
+
+# Join us
+
+We're always looking to connect with world-class thinkers, strategists, doers, and leaders. [Check out our open positions](https://jobs.lever.co/loadsmart/?department=Engineering).

--- a/hiring/careers.md
+++ b/hiring/careers.md
@@ -1,5 +1,5 @@
 ---
-title: Carrers
+title: Careers
 description: Our careers page has all of our [open positions](https://jobs.lever.co/loadsmart/?department=Engineering)
 ---
 


### PR DESCRIPTION
Add a link to our careers page: Our careers page has all of our open positions

<img width="739" alt="Screen Shot 2021-09-07 at 10 22 40 AM" src="https://user-images.githubusercontent.com/381179/132386024-862f9e39-4d3c-4cf5-a652-71d79f954e7d.png">
