### PR TITLE
add service maturity level attributes to catalog file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,6 +5,7 @@ metadata:
   description: How we work
   annotations:
     github.com/project-slug: loadsmart/culture
+    opslevel.com/tier: tier_4
   tags:
     - typescript
 spec:


### PR DESCRIPTION

### Context
The purpose of this pull request is to ensure the repository has basic attributes for service maturity level in backstage catalog, in line with the service maturity level initiative led by the Developer Productivity Squad.

### Changes

Add tags:
- `pii`, if the service stores PII data
- `internet-facing`, if the service is internet-facing
-  `django-admin`, if the service has django admin enabled

Also:
- add the service tier annotation
- update the owner, if it's defined

### Notes
- The data is based on [Loadsmart Services Tags](https://docs.google.com/spreadsheets/d/1M9z5ik96rOLzsCTAkg8WgUFUxrkrTko3ZcXjfFZ0VfY/edit#gid=0) spreadsheet
- [Service Maturity | OpsLevel internal documentation](https://loadsmart.atlassian.net/wiki/spaces/engineering/pages/3374776347/Service+Maturity+OpsLevel)
- If you are the code owner, please review the pull request and make sure the pull request is merged.
